### PR TITLE
Update PULL_REQUEST_TEMPLATE.md to show .uf2 not .bin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Ready to make a PR? Great! Make sure your directory structure looks like this:
 │   ├── case.stl \
 │   └── plate.dxf \
 ├── firmware \
+│   ├── rp2040.uf2 \
 │   └── rp2040.bin \
 └── PCB \
     ├── macropad.pro \


### PR DESCRIPTION
I updated the PR template to show a .uf2 binary file for the firmware and a .bin file. Since we're using an RP2040 board, any firmware generated by QMK/similar tools will be a .uf2 binary, so this change will cause less confusion for those trying to submit their hackpads.