### PR TITLE
Add missing submodules to .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,3 +12,12 @@
 	path = hackpads/Ambrylight/firmware
 	url = https://github.com/pmnlla/zmk-board-cfg
         branch = ambrylight
+[submodule "hackpads/bongopad/pcb/KiCad-SSD1306-128x64"]
+	path = hackpads/bongopad/pcb/KiCad-SSD1306-128x64
+	url = https://github.com/pforrmi/KiCad-SSD1306-128x64
+[submodule "hackpads/tabbyhack_k4/pcb/libraries/MX_V2"]
+	path = hackpads/tabbyhack_k4/pcb/libraries/MX_V2
+	url = https://github.com/ai03-2725/MX_V2
+[submodule "hackpads/tabbyhack_k4/pcb/libraries/OPL_Kicad_Library"]
+	path = hackpads/tabbyhack_k4/pcb/libraries/OPL_Kicad_Library
+	url = https://github.com/Seeed-Studio/OPL_Kicad_Library


### PR DESCRIPTION
This fixes submodule pulls (`--recurse-submodules` and `submodule init`), which were broken because some submodules existed in the repository's file tree but not in the gitmodules file.