### PR TITLE
Update AdvancedTutorial.mdx

### DIFF
--- a/website/src/pages/hackpad/AdvancedTutorial.mdx
+++ b/website/src/pages/hackpad/AdvancedTutorial.mdx
@@ -5,7 +5,6 @@ Are you not satisfied with a simple macropad? Here you have more information on 
 - [Ground Pour](#ground)
 - [Switch Matrix](#matrix)
 - [Silkscreen Art](#silkscreen)
-- [OLED](#oled)
 - [Jumper Wire Holes](#jumpers)
 - [Reverse Mount Neopixels](#rneopixels)
 - [Rotary Encoder](#rotary_encoder)
@@ -15,7 +14,7 @@ Are you not satisfied with a simple macropad? Here you have more information on 
   - [Creating the plate](#freecad_plate)
   - [Creating the bottom](#freecad_bottom)
 
-<a name="ground pour"/>
+<a name="ground"/>
 ## Ground Pour
 
 Do you have too many neopixels? A ground pour is a good way to remove the need to route the GND traces, and would allow current a shorter return circuit.


### PR DESCRIPTION
The Advanced DIY Guide page contains sections, of which 2 needs some very minor fixes.

The PR fixes the following:

- The OLED section was removed, so the reference to it isn't needed anymore
- The Ground Pour section is incorrectly named, so clicking the reference to it won't work