### PR TITLE
Fix SK6812MINI-E footprint to stop the model from breaking

### DIFF
--- a/extras/kicad_care_package/footprints.pretty/SK6812MINI-E_fixed.kicad_mod
+++ b/extras/kicad_care_package/footprints.pretty/SK6812MINI-E_fixed.kicad_mod
@@ -1,1 +1,371 @@
-(footprint "SK6812-rounded"(version 20241129) (generator "pcbnew") (generator_version "8.99")(layer "F.Cu" )(descr "Add-on for regular MX-footprints with SK6812 MINI-E")(tags "cherry MX SK6812 Mini-E rearmount rear mount led rgb backlight")(property "Reference" "REF**"(at 0.6 -3.1 0)(layer "F.SilkS" )(uuid "63213cd7-f2a0-4ebc-89a9-03cb9723745f")(effects(font(size 1 1)(thickness 0.2)(bold yes))))(property "Value" "SK6812MINI-E"(at 0 3.370001 0)(layer "F.Fab" )(uuid "f56cd04e-4d53-4724-a86b-1bacfbc86b65")(effects(font(size 1 1)(thickness 0.15))))(property "Footprint" ""(at 0 0 0)(layer "F.Fab" )(hide yes)(uuid "84d881be-e106-4680-9ff7-24f84b927d11")(effects(font(size 1.27 1.27)(thickness 0.15))))(property "Datasheet" ""(at 0.000001 -0.002842 0)(layer "F.Fab" )(hide yes)(uuid "6a4098c9-6158-4dd8-8ccf-aae3728b6281")(effects(font(size 1.27 1.27)(thickness 0.15))))(property "Description" ""(at 0.000001 -0.002842 0)(layer "F.Fab" )(hide yes)(uuid "2e5b7cde-6487-49be-b0d2-d9611db21223")(effects(font(size 1.27 1.27)(thickness 0.15))))(attr through_hole)(fp_poly(pts(xy 4.200001 0.897158)(xy 3.300001 1.797158)(xy 4.200001 1.797158))(stroke (width 0.1) (type solid))(fill yes)(layer "B.SilkS" )(uuid "f5241497-066f-4c5b-82f4-dbb0bb7f97a7"))(fp_line (start -1.6 -1.5) (end -1.6 1.3)(stroke (width 0.12) (type solid))(layer "Dwgs.User" )(uuid "cf8fdf7c-dc23-41d2-991d-7ae0023df893"))(fp_line (start -1.6 1.3) (end 1.1 1.3)(stroke (width 0.12) (type solid))(layer "Dwgs.User" )(uuid "4a403055-ae81-4443-b5b6-32bc368d55eb"))(fp_line (start 1.6 -1.5) (end -1.6 -1.5)(stroke (width 0.12) (type solid))(layer "Dwgs.User" )(uuid "00d48b95-94bb-44f4-acb2-45a8db659816"))(fp_line (start 1.6 0.8) (end 1.1 1.3)(stroke (width 0.12) (type solid))(layer "Dwgs.User" )(uuid "3ef8a874-22f3-4c48-90b6-116a482a761d"))(fp_line (start 1.6 0.8) (end 1.6 -1.5)(stroke (width 0.12) (type solid))(layer "Dwgs.User" )(uuid "2cbe87b2-b627-4f00-9c90-950362eca9ba"))(fp_line (start -1.699998 0.6) (end -1.699998 -0.805684)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "e028b753-8009-48bf-b44d-ce36258979bb"))(fp_line (start -0.794451 -1.602841) (end 0.794454 -1.602841)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "06f75bc0-bd89-4f61-8d61-6f2a542047b0"))(fp_line (start 0.794453 1.397158) (end -0.794451 1.397158)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "7dd8b856-652e-45a7-ba31-90c0cfde0320"))(fp_line (start 1.7 -0.805684) (end 1.7 0.6)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "94019e68-e096-4afd-b6fa-c5972363caa5"))(fp_arc (start -1.749483 -1.022562) (mid -1.712526 -0.91691) (end -1.699998 -0.805684)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "0093f363-524e-494f-987f-ed548f582c9d"))(fp_arc (start -1.749483 -1.022562) (mid -1.63807 -1.606877) (end -1.04671 -1.671141)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "12ad5a20-bdf6-4438-9fcd-82b2445053ed"))(fp_arc (start -1.699998 0.600001) (mid -1.712526 0.711226) (end -1.749483 0.816878)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "8e55909b-f4a1-49da-9b83-6b6387aed73a"))(fp_arc (start -1.04671 1.465455) (mid -1.638069 1.401192) (end -1.749483 0.816878)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "7a4ad499-c8eb-4301-94b5-6f967e9cb6a4"))(fp_arc (start -1.046709 1.465457) (mid -0.925121 1.414535) (end -0.794451 1.397158)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "514d3e20-00d4-4795-b07f-3c70bf5ad33c"))(fp_arc (start -0.794452 -1.602842) (mid -0.925122 -1.620219) (end -1.04671 -1.671141)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "7d80222a-e895-4b42-821c-59b769db8ae0"))(fp_arc (start 0.794453 1.397158) (mid 0.925124 1.414535) (end 1.046712 1.465457)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "3bb9b4fc-53cb-4e17-9e03-09e0506c991e"))(fp_arc (start 1.046712 -1.67114) (mid 0.925124 -1.620218) (end 0.794454 -1.602841)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "1b1aabd6-2c0e-44e5-9c9e-b41b95ebe611"))(fp_arc (start 1.046712 -1.67114) (mid 1.638072 -1.606876) (end 1.749485 -1.022562)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "be30f622-df0c-45e2-9a8b-4333ae163429"))(fp_arc (start 1.7 -0.805685) (mid 1.712528 -0.91691) (end 1.749485 -1.022562)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "c5a443ff-d096-4ab2-a1cc-4ff751240ddc"))(fp_arc (start 1.749485 0.816877) (mid 1.638073 1.401193) (end 1.046712 1.465457)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "72b6433c-3cb4-434c-b205-ba07176eebaf"))(fp_arc (start 1.749485 0.816878) (mid 1.712528 0.711226) (end 1.7 0.6)(stroke (width 0.1) (type solid))(layer "Edge.Cuts" )(uuid "178871c4-8ce0-47d8-9804-7b17ce24d313"))(fp_line (start -3.799999 -2.102842) (end -3.799999 1.897158)(stroke (width 0.05) (type solid))(layer "B.CrtYd" )(uuid "818ae5ad-6d04-4b19-a82e-191b54a1374a"))(fp_line (start -3.799999 1.897158) (end 3.800001 1.897158)(stroke (width 0.05) (type solid))(layer "B.CrtYd" )(uuid "b22ebc21-957f-4899-ba05-744b47e5a3ef"))(fp_line (start 3.800001 -2.102842) (end -3.799999 -2.102842)(stroke (width 0.05) (type solid))(layer "B.CrtYd" )(uuid "f8ffc992-8294-4249-a4f5-3e52dfe706ca"))(fp_line (start 3.800001 1.897158) (end 3.800001 -2.102842)(stroke (width 0.05) (type solid))(layer "B.CrtYd" )(uuid "beda627a-0e38-442a-ad7e-5cc37e8e87d3"))(fp_text user "1"(at -2.499999 -2.102842 -90)(layer "B.SilkS" )(hide yes)(uuid "3477eb2f-19d1-4a88-99ab-e99cd69a2d08")(effects(font(size 1 1)(thickness 0.15))(justify mirror)))(pad "1" smd roundrect(at -2.599999 -0.852842 270)(size 0.82 1.6)(layers  "B.Cu" "B.Mask" "B.Paste")(roundrect_rratio 0.1)(uuid "beee4f5f-4936-4983-808e-2c28c306b4bc"))(pad "2" smd roundrect(at -2.599999 0.647158 270)(size 0.82 1.6)(layers  "B.Cu" "B.Mask" "B.Paste")(roundrect_rratio 0.1)(uuid "ecdd8450-f7b2-46f9-8bb0-c9be03c372da"))(pad "3" smd roundrect(at 2.600001 0.647158 270)(size 0.82 1.6)(layers  "B.Cu" "B.Mask" "B.Paste")(roundrect_rratio 0.1)(uuid "6efe8ffd-614d-490d-8b03-2c176d454fb3"))(pad "4" smd roundrect(at 2.600001 -0.852842 270)(size 0.82 1.6)(layers  "B.Cu" "B.Mask" "B.Paste")(roundrect_rratio 0.1)(uuid "b2d162c0-ce92-4ff6-b77e-e6eb9fad6039"))(embedded_fonts no)(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_SK6812MINI_PLCC4_3.5x3.5mm_P1.75mm.wrl"(offset (xyz 0 0 0))(scale (xyz 1 1 1))(rotate (xyz 0 0 0))))
+(footprint "SK6812MINI-E_fixed"
+	(version 20241229)
+	(generator "pcbnew")
+	(generator_version "9.0")
+	(layer "F.Cu")
+	(descr "Add-on for regular MX-footprints with SK6812 MINI-E")
+	(tags "cherry MX SK6812 Mini-E rearmount rear mount led rgb backlight")
+	(property "Reference" "REF**"
+		(at 0.599999 -2.997158 0)
+		(layer "F.SilkS")
+		(uuid "6a9f3002-207d-4426-a166-63803fda1197")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.2)
+				(bold yes)
+			)
+		)
+	)
+	(property "Value" "SK6812MINI-E"
+		(at -0.000001 3.472843 0)
+		(layer "F.Fab")
+		(uuid "03cadf0a-d087-4d9b-bd1c-e75a62ffc77b")
+		(effects
+			(font
+				(size 1 1)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Datasheet" ""
+		(at 0.000001 -0.002842 0)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "3977bba9-c2b0-4293-833c-b5469ef0a509")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(property "Description" ""
+		(at 0.000001 -0.002842 0)
+		(layer "F.Fab")
+		(hide yes)
+		(uuid "8d20a1af-3b7d-4b87-8353-65a86859ee77")
+		(effects
+			(font
+				(size 1.27 1.27)
+				(thickness 0.15)
+			)
+		)
+	)
+	(attr through_hole)
+	(fp_poly
+		(pts
+			(xy 4.2 1) (xy 3.3 1.9) (xy 4.2 1.9)
+		)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(fill yes)
+		(layer "B.SilkS")
+		(uuid "f5241497-066f-4c5b-82f4-dbb0bb7f97a7")
+	)
+	(fp_line
+		(start -1.600001 -1.397158)
+		(end -1.600001 1.402842)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Dwgs.User")
+		(uuid "cf8fdf7c-dc23-41d2-991d-7ae0023df893")
+	)
+	(fp_line
+		(start -1.600001 1.402842)
+		(end 1.099999 1.402842)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Dwgs.User")
+		(uuid "4a403055-ae81-4443-b5b6-32bc368d55eb")
+	)
+	(fp_line
+		(start 1.599999 -1.397158)
+		(end -1.600001 -1.397158)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Dwgs.User")
+		(uuid "00d48b95-94bb-44f4-acb2-45a8db659816")
+	)
+	(fp_line
+		(start 1.599999 0.902842)
+		(end 1.099999 1.402842)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Dwgs.User")
+		(uuid "3ef8a874-22f3-4c48-90b6-116a482a761d")
+	)
+	(fp_line
+		(start 1.599999 0.902842)
+		(end 1.599999 -1.397158)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Dwgs.User")
+		(uuid "2cbe87b2-b627-4f00-9c90-950362eca9ba")
+	)
+	(fp_line
+		(start -1.7 -0.75449)
+		(end -1.7 0.754491)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "89f1c182-1501-4729-bd39-ca6a92df5e12")
+	)
+	(fp_line
+		(start -0.850571 -1.5)
+		(end 0.853891 -1.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "73314211-333b-4dd7-9cd2-0e65f33d249b")
+	)
+	(fp_line
+		(start -0.850571 1.5)
+		(end 0.8506 1.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "6729af60-085f-4495-bc2d-323ea16304f3")
+	)
+	(fp_line
+		(start 1.7 0.754489)
+		(end 1.7 -0.7545)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "f6aebe50-0bc7-4dc1-b92a-8113f7c65afb")
+	)
+	(fp_arc
+		(start -1.741694 -0.892722)
+		(mid -1.71065 -0.826682)
+		(end -1.7 -0.75449)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "5e1ee8c3-c8c5-43b6-9126-bb09bc0b511a")
+	)
+	(fp_arc
+		(start -1.741694 -0.892722)
+		(mid -1.660684 -1.539824)
+		(end -1.008742 -1.556396)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "42efffaf-435f-4f2e-b52e-8ad874c211fa")
+	)
+	(fp_arc
+		(start -1.7 0.754491)
+		(mid -1.71065 0.826682)
+		(end -1.741694 0.892722)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "13a9f391-282e-4dca-bb74-9eeb4475b5d6")
+	)
+	(fp_arc
+		(start -1.008742 1.556396)
+		(mid -1.660684 1.539824)
+		(end -1.741694 0.892722)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "b46a7869-d392-4db6-a6d6-91ef00918c06")
+	)
+	(fp_arc
+		(start -1.008742 1.556396)
+		(mid -0.934533 1.514521)
+		(end -0.850571 1.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "280a7869-c68b-4d07-b22c-b7ec3ce1e6d7")
+	)
+	(fp_arc
+		(start -0.850571 -1.5)
+		(mid -0.934533 -1.514521)
+		(end -1.008742 -1.556396)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "8c529f97-c704-418f-99af-cf0771cd63f5")
+	)
+	(fp_arc
+		(start 0.8506 1.5)
+		(mid 0.934546 1.514522)
+		(end 1.008742 1.556396)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "80cc0dc4-2d5f-468a-a37b-162d42c693a4")
+	)
+	(fp_arc
+		(start 1.008742 -1.556396)
+		(mid 0.936091 -1.515086)
+		(end 0.853891 -1.5)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "c6d5b07b-408f-4ed3-ac65-265d8c8d6148")
+	)
+	(fp_arc
+		(start 1.008742 -1.556396)
+		(mid 1.660689 -1.539827)
+		(end 1.741694 -0.892722)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "956e7655-9d8c-4389-a900-539841b08964")
+	)
+	(fp_arc
+		(start 1.7 -0.7545)
+		(mid 1.710652 -0.826686)
+		(end 1.741694 -0.892722)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "c71267e1-e511-4376-bc88-fe6b066e4ed0")
+	)
+	(fp_arc
+		(start 1.741694 0.892722)
+		(mid 1.660686 1.539824)
+		(end 1.008742 1.556396)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "440c003f-a390-450a-8f52-9b67b919d082")
+	)
+	(fp_arc
+		(start 1.741694 0.892722)
+		(mid 1.710668 0.826678)
+		(end 1.7 0.754489)
+		(stroke
+			(width 0.12)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+		(uuid "d1100fd9-e413-4d84-81c6-4c4d8cc47188")
+	)
+	(fp_line
+		(start -3.8 -2)
+		(end -3.8 2)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "B.CrtYd")
+		(uuid "818ae5ad-6d04-4b19-a82e-191b54a1374a")
+	)
+	(fp_line
+		(start -3.8 2)
+		(end 3.8 2)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "B.CrtYd")
+		(uuid "b22ebc21-957f-4899-ba05-744b47e5a3ef")
+	)
+	(fp_line
+		(start 3.8 -2)
+		(end -3.8 -2)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "B.CrtYd")
+		(uuid "f8ffc992-8294-4249-a4f5-3e52dfe706ca")
+	)
+	(fp_line
+		(start 3.8 2)
+		(end 3.8 -2)
+		(stroke
+			(width 0.05)
+			(type solid)
+		)
+		(layer "B.CrtYd")
+		(uuid "beda627a-0e38-442a-ad7e-5cc37e8e87d3")
+	)
+	(pad "1" smd roundrect
+		(at -2.6 -0.75 270)
+		(size 0.82 1.6)
+		(layers "B.Cu" "B.Mask" "B.Paste")
+		(roundrect_rratio 0.1)
+		(uuid "beee4f5f-4936-4983-808e-2c28c306b4bc")
+	)
+	(pad "2" smd roundrect
+		(at -2.6 0.75 270)
+		(size 0.82 1.6)
+		(layers "B.Cu" "B.Mask" "B.Paste")
+		(roundrect_rratio 0.1)
+		(uuid "ecdd8450-f7b2-46f9-8bb0-c9be03c372da")
+	)
+	(pad "3" smd roundrect
+		(at 2.6 0.75 270)
+		(size 0.82 1.6)
+		(layers "B.Cu" "B.Mask" "B.Paste")
+		(roundrect_rratio 0.1)
+		(uuid "6efe8ffd-614d-490d-8b03-2c176d454fb3")
+	)
+	(pad "4" smd roundrect
+		(at 2.6 -0.75 270)
+		(size 0.82 1.6)
+		(layers "B.Cu" "B.Mask" "B.Paste")
+		(roundrect_rratio 0.1)
+		(uuid "b2d162c0-ce92-4ff6-b77e-e6eb9fad6039")
+	)
+	(group ""
+		(uuid "ee2e65fa-7af3-4408-8fc5-9fadb007516e")
+		(members "13a9f391-282e-4dca-bb74-9eeb4475b5d6" "280a7869-c68b-4d07-b22c-b7ec3ce1e6d7"
+			"42efffaf-435f-4f2e-b52e-8ad874c211fa" "440c003f-a390-450a-8f52-9b67b919d082"
+			"5e1ee8c3-c8c5-43b6-9126-bb09bc0b511a" "6729af60-085f-4495-bc2d-323ea16304f3"
+			"73314211-333b-4dd7-9cd2-0e65f33d249b" "80cc0dc4-2d5f-468a-a37b-162d42c693a4"
+			"89f1c182-1501-4729-bd39-ca6a92df5e12" "8c529f97-c704-418f-99af-cf0771cd63f5"
+			"956e7655-9d8c-4389-a900-539841b08964" "b46a7869-d392-4db6-a6d6-91ef00918c06"
+			"c6d5b07b-408f-4ed3-ac65-265d8c8d6148" "c71267e1-e511-4376-bc88-fe6b066e4ed0"
+			"d1100fd9-e413-4d84-81c6-4c4d8cc47188" "f6aebe50-0bc7-4dc1-b92a-8113f7c65afb"
+		)
+	)
+	(embedded_fonts no)
+)


### PR DESCRIPTION
Fix the SK6812MINI-E footprint. The original had some unconnected spots in the edge.cuts that would make step files that were exported from PCBs with the footprint have random lines. 

I did **NOT** add any clearance to the pads because when I tried to it would break the exported model again.

Original:
<img width="1338" height="937" alt="image" src="https://github.com/user-attachments/assets/aac2c6ea-638f-40d5-b39f-a7d4b072075a" />


New: 
<img width="1294" height="886" alt="image" src="https://github.com/user-attachments/assets/f763a165-4a02-47f6-af84-ec03d5423e4a" />

