### PR TITLE
Fix code block formatting in SimpleTutorial.mdx

### DIFF
--- a/website/src/pages/hackpad/SimpleTutorial.mdx
+++ b/website/src/pages/hackpad/SimpleTutorial.mdx
@@ -118,9 +118,7 @@ Extrude the sides by 10mm (it should be 13mm tall in total!):
 That's the bottom half of the plate done. Next, we're going to make the plate. Head on over to [ai03's plate generator](https://kbplate.ai03.com/)
 and paste in the following data:
 
-```
-["","",""],
-```
+<pre><code>{`["","",""],`}</code></pre>
 
 That should generate a plate. Hit download DXF, and then import that into Fusion 360 - make sure that the plate is centered!
 <img src="/docs/v1/platesketch.png" className="max-w-96" />


### PR DESCRIPTION
Updated code block formatting for clarity in tutorial.

In current web site, the last comma isn't appeared: ["","",""]
↑It should be : ["","",""],
Because without the last comma, plate generator couldn't work well.

Hackpad submissions should no longer be done through PRs - instead, please submit to the current active program! For reference, this is what the old message used to look like:

```
Ready to submit your project? Nice job! Hopefully you've read the [submission guidelines](https://hackpad.hackclub.com/submitting). **If not, make sure to read them first.**

Check off the following to let the reviewers know you've done everything:
[] I HAVE RAN DRC ON MY DESIGN WITH ZERO ERRORS (Silkscreen errors are okay)
[] I HAVE BRANDED ALL MY PARTS (PCB, CASE) WITH MY HACKPAD'S NAME
[] I HAVE MADE SURE MY 3D PRINTED PARTS DO NOT REQUIRE SUPPORTS (Text branding overhang is okay)
[] I HAVE MADE SURE TO INCLUDE TOLERANCES (0.25mm)
[] MY HACKPAD'S PCB IS UNDER 100mm x 100mm, I DO NOT HAVE MORE THAN 16X SWITCHES, 2X ROTARY ENCODERS, 1X OLED, 16X LEDS.
[] IN MY FOLDER, THERE IS A README.MD FILE THAT CONTAINS THE FOLLOWING INFORMATION:
- Full render including all the parts
- A few sentences about the inspiration and challenges
- BOM
- Photos of the Schematic, PCB, and case

If you're unsure about the format, make sure to check out this [example]([insertexample](https://github.com/hackclub/hackpad/tree/main/hackpads/Duccs%20Fidget%20Toy)) and follow the format there.

If this PR isn't a submission, that's okay too! Please remove the above boxes and explain what the pull request is for! If there's anything about this PR template that seems confusing, send a message in #hackpad in slack!
```
